### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gatsby-build.yml
+++ b/.github/workflows/gatsby-build.yml
@@ -3,6 +3,9 @@
 
 name: Gatsby Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/OpenArchitex/PythonSinhala/security/code-scanning/1](https://github.com/OpenArchitex/PythonSinhala/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not perform any operations requiring write permissions, we can set the permissions to `contents: read`, which is the minimal privilege required for most CI workflows. This change should be applied at the root level of the workflow to cover all jobs unless specific jobs require additional permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
